### PR TITLE
[CIR-2686] Correct readme and helper script

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,26 +16,8 @@ If you don't have postgres installed locally you can run it in docker using the 
 
     docker run -d --rm --name postgresql -e POSTGRES_USER=postgres -e POSTGRES_PASSWORD=postgres -p 5432:5432 postgres:10.14
 
-Start the dependent services by running the `.start_services.sh` script. Alternative, you can run the command below manually:
+Start the dependent services by running the `.start_services.sh` script.
 
-```shell
-    sm2 --start BANK_ACCOUNT_INSIGHTS_PROXY BANK_ACCOUNT_GATEWAY BANK_ACCOUNT_INSIGHTS INTERNAL_AUTH --appendArgs \
-    '{
-      "BANK_ACCOUNT_INSIGHTS_PROXY": [
-        "-Dmicroservice.services.access-control.enabled=true",
-        "-Dmicroservice.services.access-control.allow-list.0=bank-account-gateway",
-        "-Dmicroservice.services.access-control.allow-list.1=allowed-test-hmrc-service",
-        "-Dapplication.router=testOnlyDoNotUseInAppConf.Routes"
-      ],
-      "BANK_ACCOUNT_INSIGHTS": [
-        "-Dauditing.consumer.baseUri.port=6001",
-        "-Dauditing.consumer.baseUri.host=localhost",
-        "-Dauditing.enabled=true",
-        "-Dmicroservice.risk-lists.database.use-canned-data=true",
-        "-Dmicroservice.bank-account-insights.database.use-canned-data=true"
-      ]
-    }'
-```
 ### Running specs
 
 Execute the `run_specs.sh` script:

--- a/start_services.sh
+++ b/start_services.sh
@@ -12,7 +12,6 @@ sm2 --start BANK_ACCOUNT_INSIGHTS_PROXY BANK_ACCOUNT_GATEWAY BANK_ACCOUNT_INSIGH
         "-Dauditing.consumer.baseUri.port=6001",
         "-Dauditing.consumer.baseUri.host=localhost",
         "-Dauditing.enabled=true",
-        "-Dmicroservice.risk-lists.database.use-canned-data=true",
-        "-Dmicroservice.bank-account-insights.database.use-canned-data=true"
+        "-Ddb.default.use-canned-data=true"
       ]
     }'


### PR DESCRIPTION
- removes duplication and just reference the `./start-services.sh` helper from the readme directly.